### PR TITLE
Fix GitHub Actions build process for Windows and Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,23 +31,26 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
+      - name: Install system dependencies (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y binutils
+
       - name: Install dependencies
         run: |
           uv pip install -e ".[gui]"
           uv pip install pyinstaller pillow
 
-      - name: Generate spec file (Windows)
+      - name: Build executable (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          uv run pyinstaller --name "Dive Color Corrector" --windowed --onefile --icon "logo/logo.png" --add-data "src/dive_color_corrector/gui/assets;dive_color_corrector/gui/assets" --clean --noconfirm src/dive_color_corrector/__main__.py
+          uv run pyinstaller --name "Dive Color Corrector" --windowed --onefile --icon "src/dive_color_corrector/gui/assets/logo.png" --add-data "src/dive_color_corrector/gui/assets;dive_color_corrector/gui/assets" --clean --noconfirm src/dive_color_corrector/__main__.py
 
-      - name: Generate spec file (Unix)
+      - name: Build executable (Unix)
         if: matrix.os != 'windows-latest'
         run: |
-          uv run pyinstaller --name "Dive Color Corrector" --windowed --onefile --icon "logo/logo.png" --add-data "src/dive_color_corrector/gui/assets:dive_color_corrector/gui/assets" --clean --noconfirm src/dive_color_corrector/__main__.py
-
-      - name: Build executable
-        run: uv run pyinstaller --clean --noconfirm "Dive Color Corrector.spec"
+          uv run pyinstaller --name "Dive Color Corrector" --windowed --onefile --icon "src/dive_color_corrector/gui/assets/logo.png" --add-data "src/dive_color_corrector/gui/assets:dive_color_corrector/gui/assets" --clean --noconfirm src/dive_color_corrector/__main__.py
 
       - name: List files (Windows)
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
This commit addresses several critical issues in the build workflow:

1. Fixed icon path: Changed from non-existent "logo/logo.png" to actual location "src/dive_color_corrector/gui/assets/logo.png"

2. Removed redundant build step: The pyinstaller command with --onefile flag already builds the executable, so the second build step was unnecessary and has been removed

3. Added Linux system dependencies: Installed binutils package which is required for PyInstaller to work correctly on Linux

4. Renamed steps from "Generate spec file" to "Build executable" to better reflect what they actually do

These changes ensure that GitHub Actions can successfully build working artifacts for both Windows and Linux platforms.